### PR TITLE
RHTAPBUGS-929 don't rely on Tekon labels

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 == RHTAP Multi Platform Controller
 
-This controller orchestrates remote agents for RTHAP. It watches for `TaskRun` instances with the `build.appstudio.redhat.com/multi-platform-required` label, and will then supply SSH credentials for a node of the requested platform. The `TaskRun` can then use this node to build using a different platform. When the `TaskRun` is done the controller deals with cleanup up the remote node.
+This controller orchestrates remote agents for RTHAP. It watches for `TaskRun` instances that need a secret that starts with `multi-platform-ssh-` prefix and have a PLATFORM parameter, and will then supply SSH credentials for a node of the requested platform. The `TaskRun` can then use this node to build using a different platform. When the `TaskRun` is done the controller deals with cleanup up the remote node.
 
 == Try It Out
 

--- a/cmd/taskgen/main.go
+++ b/cmd/taskgen/main.go
@@ -182,7 +182,6 @@ fi
 	}
 
 	task.Name = "buildah-remote"
-	task.Labels["build.appstudio.redhat.com/multi-platform-required"] = "true"
 	task.Spec.Params = append(task.Spec.Params, pipelinev1beta1.ParamSpec{Name: "PLATFORM", Type: pipelinev1beta1.ParamTypeString, Description: "The platform to build on"})
 
 	faleVar := false

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -63,14 +63,6 @@ func NewManager(cfg *rest.Config, options ctrl.Options) (ctrl.Manager, error) {
 	var mgr ctrl.Manager
 	var err error
 
-	//if we are running this locally on the same cluster as the ckcp we want to ignore any synced pipeline runs
-	multiArchPipelines := labels.NewSelector()
-	requirement, lerr := labels.NewRequirement(taskrun.MultiPlatformLabel, selection.Exists, nil)
-	if lerr != nil {
-		return nil, lerr
-	}
-	multiArchPipelines = multiArchPipelines.Add(*requirement)
-
 	configMapSelector := labels.NewSelector()
 	configMapLabels, lerr := labels.NewRequirement(taskrun.ConfigMapLabel, selection.Exists, []string{})
 	if lerr != nil {
@@ -87,7 +79,7 @@ func NewManager(cfg *rest.Config, options ctrl.Options) (ctrl.Manager, error) {
 
 	options.Cache = cache.Options{
 		ByObject: map[client.Object]cache.ByObject{
-			&pipelinev1.TaskRun{}: {Label: multiArchPipelines},
+			&pipelinev1.TaskRun{}: {},
 			&v1.Secret{}:          {Label: secretSelector},
 			&v1.ConfigMap{}:       {Label: configMapSelector},
 		},

--- a/pkg/reconciler/taskrun/hostpool.go
+++ b/pkg/reconciler/taskrun/hostpool.go
@@ -122,7 +122,7 @@ func (hp HostPool) Deallocate(r *ReconcileTaskRun, ctx context.Context, log *log
 		provision := v1.TaskRun{}
 		provision.GenerateName = "cleanup-task"
 		provision.Namespace = r.operatorNamespace
-		provision.Labels = map[string]string{TaskTypeLabel: TaskTypeClean, UserTaskName: tr.Name, UserTaskNamespace: tr.Namespace, MultiPlatformLabel: "true"}
+		provision.Labels = map[string]string{TaskTypeLabel: TaskTypeClean, UserTaskName: tr.Name, UserTaskNamespace: tr.Namespace}
 		provision.Spec.TaskRef = &v1.TaskRef{Name: "clean-shared-host"}
 		provision.Spec.Workspaces = []v1.WorkspaceBinding{{Name: "ssh", Secret: &v12.SecretVolumeSource{SecretName: selected.Secret}}}
 		provision.Spec.ServiceAccountName = ServiceAccountName //TODO: special service account for this

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -407,11 +407,12 @@ func createUserTaskRun(g *WithT, client runtimeclient.Client, name string, platf
 	tr := &pipelinev1.TaskRun{}
 	tr.Namespace = userNamespace
 	tr.Name = name
-	tr.Labels = map[string]string{MultiPlatformLabel: "true"}
 	tr.Spec = pipelinev1.TaskRunSpec{
 		Params: []pipelinev1.Param{{Name: PlatformParam, Value: *pipelinev1.NewStructuredValues(platform)}},
 	}
+	tr.Status.TaskSpec = &pipelinev1.TaskSpec{Volumes: []v1.Volume{{Name: "test", VolumeSource: v1.VolumeSource{Secret: &v1.SecretVolumeSource{SecretName: SecretPrefix + name}}}}}
 	g.Expect(client.Create(context.TODO(), tr)).ToNot(HaveOccurred())
+
 }
 
 func createHostConfig() []runtimeclient.Object {


### PR DESCRIPTION
The copying of labels from Task to TaskRun is going away, and is unreliable anyway. Now we just rely on tasks attempting to inject the specified secret and specifying a platform.