### PR TITLE
Fix the SELinux labels after copying ssh keys

### DIFF
--- a/deploy/operator/provision-shared-host.yaml
+++ b/deploy/operator/provision-shared-host.yaml
@@ -48,6 +48,7 @@ spec:
         sudo su $USERNAME -c 'mkdir /home/$USERNAME/build'
         sudo mv $USERNAME.pub /home/$USERNAME/.ssh/authorized_keys
         sudo chown $USERNAME /home/$USERNAME/.ssh/authorized_keys
+        sudo restorecon -FRvv /home/$USERNAME/.ssh
         EOF
         ssh -i /tmp/master_key -o StrictHostKeyChecking=no $SSH_HOST "bash -s" <script.sh
         ssh -i /tmp/master_key -o StrictHostKeyChecking=no $SSH_HOST cat $USERNAME  >id_rsa


### PR DESCRIPTION
We were seeing an issue where SSH connections were rejected even when the public and private keys were matching. After fixing the SELinux labels, the SSH connections were allowed.

https://stackoverflow.com/a/20818775