### PR TITLE
KFLUXBUGS-1337 fix issue with s390x

### DIFF
--- a/pkg/ibm/ibmp.go
+++ b/pkg/ibm/ibmp.go
@@ -136,7 +136,7 @@ func (r IBMPowerDynamicConfig) GetInstanceAddress(kubeClient client.Client, ctx 
 	if err != nil {
 		return "", nil //todo: check for permanent errors
 	}
-	return checkAddressLive(ctx, ip)
+	return checkAddressLive(ctx, ip), err
 }
 
 func (r IBMPowerDynamicConfig) ListInstances(kubeClient client.Client, ctx context.Context, instanceTag string) ([]cloud.CloudVMInstance, error) {


### PR DESCRIPTION
If the ip is not established yet it can return 0.0.0.0 as the address, we need to guard against this.