### PR TITLE
Move container_path to /shared volume

### DIFF
--- a/cmd/taskgen/main.go
+++ b/cmd/taskgen/main.go
@@ -189,7 +189,7 @@ fi
 		ret += "\nbuildah pull oci:rhtap-final-image"
 		ret += "\nbuildah images"
 		ret += "\nbuildah tag localhost/rhtap-final-image \"$IMAGE\""
-		ret += "\ncontainer=$(buildah from --pull-never \"$IMAGE\")\nbuildah mount \"$container\" | tee /workspace/container_path\necho $container > /workspace/container_name"
+		ret += "\ncontainer=$(buildah from --pull-never \"$IMAGE\")\nbuildah mount \"$container\" | tee /shared/container_path\necho $container > /shared/container_name"
 
 		for _, i := range strings.Split(ret, "\n") {
 			if strings.HasSuffix(i, " ") {


### PR DESCRIPTION
The existing /workspace path is an internal implementation detail, and is not guarenteed to work. Using /shared means we can make it consistent between both buildah tasks.